### PR TITLE
adds settings to enable/disable htmlawed filtering of url and title

### DIFF
--- a/actions/edit.php
+++ b/actions/edit.php
@@ -1,7 +1,11 @@
 <?php 
+	$filter = true;
+	if (elgg_get_plugin_setting('htmlawed_filter', 'menu_builder') == 'no') {
+	  $filter = false;
+	}
 
-	$title = get_input("title");
-	$url = get_input("url");
+	$title = get_input("title", '', $filter);
+	$url = get_input("url", '', $filter);
 	$target = get_input("target");
 	$access_id = (int) get_input("access_id", ACCESS_DEFAULT);
 	$parent_guid = (int) get_input("parent_guid", 0);

--- a/languages/en.php
+++ b/languages/en.php
@@ -46,6 +46,9 @@
 	
 		'menu_builder:actions:delete:success' => "The menu item was deleted successfully",
 		
+		// settings
+		'menu_builder:htmlawed:filter' => "Filter url and titles through htmlawed?",
+		
 	);
 					
 	add_translation("en",$english);

--- a/views/default/plugins/menu_builder/settings.php
+++ b/views/default/plugins/menu_builder/settings.php
@@ -1,0 +1,14 @@
+<?php
+
+echo elgg_echo('menu_builder:htmlawed:filter') . '<br>';
+
+echo elgg_view('input/dropdown', array(
+	'name' => 'params[htmlawed_filter]',
+	'value' => $vars['entity']->htmlawed_filter ? $vars['entity']->htmlawed_filter : 'yes',
+	'options_values' => array(
+		'yes' => elgg_echo('option:yes'),
+		'no' => elgg_echo('option:no')
+	)
+));
+
+echo '<br><br>';


### PR DESCRIPTION
HTMLawed strips out style settings that could be useful - eg background images.  Since it's admins editing the menu it makes sense to allow such attributes.  This gives a plugin setting to toggle filtering of the url/title.
