### PR TITLE
fixes url tokenization with respect to wwwroot when elgg is installed in...

### DIFF
--- a/pages/edit.php
+++ b/pages/edit.php
@@ -72,8 +72,8 @@
 		if(empty($guid)){
 		?>
 		<script type="text/javascript">
-			var url_path = window.location.pathname;
-			url_path = "[wwwroot]" + url_path.substr(1).replace("<?php echo elgg_get_logged_in_user_entity()->username;?>", "[username]")<?php if(elgg_get_page_owner_entity()){ ?>.replace("<?php echo page_owner_entity()->username; ?>", "[username]")<?php } ?>;
+			var url_path = window.location.href;
+			url_path = url_path.replace("<?php echo elgg_get_site_url(); ?>", "[wwwroot]").replace("<?php echo elgg_get_logged_in_user_entity()->username;?>", "[username]")<?php if(elgg_get_page_owner_entity()){ ?>.replace("<?php echo page_owner_entity()->username; ?>", "[username]")<?php } ?>;
 
 			var window_title = document.title.replace("<?php echo elgg_get_site_entity()->name. ": "; ?>", "");
 			$("#menu_builder_add_form input[name='title']").val(window_title).focus();


### PR DESCRIPTION
... a subdirectory to prevent path duplication

Without this change, if elgg is installed in a directory eg. [domain]/elgg
Adding a new menu item would tokenize the url as [wwwroot]elgg/path/to/page
And the resulting menu item would point to [domain]/elgg/elgg/path/to/page
Note the duplication of /elgg
